### PR TITLE
adapt to lerobot act

### DIFF
--- a/gym_kmanip/__init__.py
+++ b/gym_kmanip/__init__.py
@@ -157,15 +157,15 @@ class Cam:
 CAMERAS: OrderedDict[str, Cam] = ODict()
 CAMERAS["head"] = Cam(640, 480, 3, 448, (320, 240), "head", "camera/head")
 CAMERAS["top"] = Cam(640, 480, 3, 448, (320, 240), "top", "camera/top")
-CAMERAS["grip_r"] = Cam(60, 40, 3, 45, (30, 20), "grip_r", "camera/grip_r")
+CAMERAS["grip_r"] = Cam(640, 480, 3, 448, (30, 20), "grip_r", "camera/grip_r")
 CAMERAS["grip_l"] = Cam(60, 40, 3, 45, (30, 20), "grip_l", "camera/grip_l")
 
 # cube is randomly spawned on episode start
 CUBE_SPAWN_RANGE: NDArray = np.array(
     [
-        [0.1, 0.3],  # X
-        [0.5, 0.7],  # Y
-        [0.6, 0.7],  # Z
+        [0.1, 0.12],  # X
+        [0.5, 0.712],  # Y
+        [0.6, 0.605],  # Z
     ]
 )
 
@@ -242,7 +242,7 @@ def vuer2mj_orn(orn: R) -> NDArray:
 
 
 register(
-    id="KManipSoloArm",
+    id="gym_kmanip/KManipSoloArm",
     entry_point="gym_kmanip.env_base:KManipEnv",
     max_episode_steps=MAX_EPISODE_STEPS,
     nondeterministic=True,
@@ -269,7 +269,7 @@ register(
 )
 
 register(
-    id="KManipSoloArmQPos",
+    id="gym_kmanip/KManipSoloArmQPos",
     entry_point="gym_kmanip.env_base:KManipEnv",
     max_episode_steps=MAX_EPISODE_STEPS,
     nondeterministic=True,
@@ -295,8 +295,36 @@ register(
 )
 
 
+# register(
+#     id="gym_kmanip/KManipSoloArmVision",
+#     entry_point="gym_kmanip.env_base:KManipEnv",
+#     max_episode_steps=MAX_EPISODE_STEPS,
+#     nondeterministic=True,
+#     kwargs={
+#         "mjcf_filename": SOLO_ARM_MJCF,
+#         "urdf_filename": SOLO_ARM_URDF,
+#         "obs_list": [
+#             "q_pos",  # joint positions
+#             "q_vel",  # joint velocities
+#             "camera/head",  # robot head camera
+#             "camera/grip_r",  # right gripper camera
+#         ],
+#         "act_list": [
+#             "eer_pos",  # right end effector position
+#             "eer_orn",  # right end effector orientation
+#             "grip_r",  # right gripper
+#             # "q_pos",  # joint positions for right arm
+#         ],
+#         "q_pos_home": Q_SOLO_ARM_HOME,
+#         "q_dict": Q_SOLO_ARM_HOME_DICT,
+#         "q_keys": Q_SOLO_ARM_KEYS,
+#         "q_id_r_mask": Q_ID_R_MASK_SOLO,
+#         "ctrl_id_r_grip": CTRL_ID_R_GRIP_SOLO,
+#     },
+# )
+
 register(
-    id="KManipSoloArmVision",
+    id="gym_kmanip/KManipSoloArmVision",
     entry_point="gym_kmanip.env_base:KManipEnv",
     max_episode_steps=MAX_EPISODE_STEPS,
     nondeterministic=True,
@@ -304,12 +332,14 @@ register(
         "mjcf_filename": SOLO_ARM_MJCF,
         "urdf_filename": SOLO_ARM_URDF,
         "obs_list": [
+            # without qpos formatting won't work
             "q_pos",  # joint positions
             "q_vel",  # joint velocities
             "camera/head",  # robot head camera
             "camera/grip_r",  # right gripper camera
         ],
         "act_list": [
+            "q_pos",  # joint positions for right arm
             "eer_pos",  # right end effector position
             "eer_orn",  # right end effector orientation
             "grip_r",  # right gripper
@@ -319,165 +349,5 @@ register(
         "q_keys": Q_SOLO_ARM_KEYS,
         "q_id_r_mask": Q_ID_R_MASK_SOLO,
         "ctrl_id_r_grip": CTRL_ID_R_GRIP_SOLO,
-    },
-)
-
-register(
-    id="KManipDualArm",
-    entry_point="gym_kmanip.env_base:KManipEnv",
-    max_episode_steps=MAX_EPISODE_STEPS,
-    nondeterministic=True,
-    kwargs={
-        "mjcf_filename": DUAL_ARM_MJCF,
-        "urdf_filename": DUAL_ARM_URDF,
-        "obs_list": [
-            "q_pos",  # joint positions
-            "q_vel",  # joint velocities
-            "cube_pos",  # cube position
-            "cube_orn",  # cube orientation
-        ],
-        "act_list": [
-            "eel_pos",  # left end effector position
-            "eel_orn",  # left end effector orientation
-            "eer_pos",  # right end effector position
-            "eer_orn",  # right end effector orientation
-            "grip_l",  # left gripper
-            "grip_r",  # right gripper
-        ],
-        "q_pos_home": Q_DUAL_ARM_HOME,
-        "q_dict": Q_DUAL_ARM_HOME_DICT,
-        "q_keys": Q_DUAL_ARM_KEYS,
-        "q_id_r_mask": Q_ID_R_MASK_DUAL,
-        "q_id_l_mask": Q_ID_L_MASK_DUAL,
-        "ctrl_id_r_grip": CTRL_ID_R_GRIP_DUAL,
-        "ctrl_id_l_grip": CTRL_ID_L_GRIP_DUAL,
-    },
-)
-
-register(
-    id="KManipDualArmQPos",
-    entry_point="gym_kmanip.env_base:KManipEnv",
-    max_episode_steps=MAX_EPISODE_STEPS,
-    nondeterministic=True,
-    kwargs={
-        "mjcf_filename": DUAL_ARM_MJCF,
-        "urdf_filename": DUAL_ARM_URDF,
-        "obs_list": [
-            "q_pos",  # joint positions
-            "q_vel",  # joint velocities
-            "cube_pos",  # cube position
-            "cube_orn",  # cube orientation
-        ],
-        "act_list": [
-            "q_pos_r",  # joint positions for right arm
-            "q_pos_l",  # joint positions for left arm
-            "grip_l",  # left gripper
-            "grip_r",  # right gripper
-        ],
-        "q_pos_home": Q_DUAL_ARM_HOME,
-        "q_dict": Q_DUAL_ARM_HOME_DICT,
-        "q_keys": Q_DUAL_ARM_KEYS,
-        "q_id_r_mask": Q_ID_R_MASK_DUAL,
-        "q_id_l_mask": Q_ID_L_MASK_DUAL,
-        "ctrl_id_r_grip": CTRL_ID_R_GRIP_DUAL,
-        "ctrl_id_l_grip": CTRL_ID_L_GRIP_DUAL,
-    },
-)
-
-register(
-    id="KManipDualArmVision",
-    entry_point="gym_kmanip.env_base:KManipEnv",
-    max_episode_steps=MAX_EPISODE_STEPS,
-    nondeterministic=True,
-    kwargs={
-        "mjcf_filename": DUAL_ARM_MJCF,
-        "urdf_filename": DUAL_ARM_URDF,
-        "obs_list": [
-            "q_pos",  # joint positions
-            "q_vel",  # joint velocities
-            "camera/head",  # robot head camera
-            "camera/grip_l",  # left gripper camera
-            "camera/grip_r",  # right gripper camera
-        ],
-        "act_list": [
-            "eel_pos",  # left end effector position
-            "eel_orn",  # left end effector orientation
-            "eer_pos",  # right end effector position
-            "eer_orn",  # right end effector orientation
-            "grip_l",  # left gripper
-            "grip_r",  # right gripper
-        ],
-        "q_pos_home": Q_DUAL_ARM_HOME,
-        "q_dict": Q_DUAL_ARM_HOME_DICT,
-        "q_keys": Q_DUAL_ARM_KEYS,
-        "q_id_r_mask": Q_ID_R_MASK_DUAL,
-        "q_id_l_mask": Q_ID_L_MASK_DUAL,
-        "ctrl_id_r_grip": CTRL_ID_R_GRIP_DUAL,
-        "ctrl_id_l_grip": CTRL_ID_L_GRIP_DUAL,
-    },
-)
-
-register(
-    id="KManipTorso",
-    entry_point="gym_kmanip.env_base:KManipEnv",
-    max_episode_steps=MAX_EPISODE_STEPS,
-    nondeterministic=True,
-    kwargs={
-        "mjcf_filename": TORSO_MJCF,
-        "urdf_filename": TORSO_URDF,
-        "obs_list": [
-            "q_pos",  # joint positions
-            "q_vel",  # joint velocities
-            "cube_pos",  # cube position
-            "cube_orn",  # cube orientation
-        ],
-        "act_list": [
-            "eel_pos",  # left end effector position
-            "eel_orn",  # left end effector orientation
-            "eer_pos",  # right end effector position
-            "eer_orn",  # right end effector orientation
-            "grip_l",  # left gripper
-            "grip_r",  # right gripper
-        ],
-        "q_pos_home": Q_TORSO_HOME,
-        "q_dict": Q_TORSO_HOME_DICT,
-        "q_keys": Q_TORSO_KEYS,
-        "q_id_r_mask": Q_ID_R_MASK_TORSO,
-        "q_id_l_mask": Q_ID_L_MASK_TORSO,
-        "ctrl_id_r_grip": CTRL_ID_R_GRIP_TORSO,
-        "ctrl_id_l_grip": CTRL_ID_L_GRIP_TORSO,
-    },
-)
-
-register(
-    id="KManipTorsoVision",
-    entry_point="gym_kmanip.env_base:KManipEnv",
-    max_episode_steps=MAX_EPISODE_STEPS,
-    nondeterministic=True,
-    kwargs={
-        "mjcf_filename": TORSO_MJCF,
-        "urdf_filename": TORSO_URDF,
-        "obs_list": [
-            "q_pos",  # joint positions
-            "q_vel",  # joint velocities
-            "camera/head",  # robot head camera
-            "camera/grip_l",  # left gripper camera
-            "camera/grip_r",  # right gripper camera
-        ],
-        "act_list": [
-            "eel_pos",  # left end effector position
-            "eel_orn",  # left end effector orientation
-            "eer_pos",  # right end effector position
-            "eer_orn",  # right end effector orientation
-            "grip_l",  # left gripper
-            "grip_r",  # right gripper
-        ],
-        "q_pos_home": Q_TORSO_HOME,
-        "q_dict": Q_TORSO_HOME_DICT,
-        "q_keys": Q_TORSO_KEYS,
-        "q_id_r_mask": Q_ID_R_MASK_TORSO,
-        "q_id_l_mask": Q_ID_L_MASK_TORSO,
-        "ctrl_id_r_grip": CTRL_ID_R_GRIP_TORSO,
-        "ctrl_id_l_grip": CTRL_ID_L_GRIP_TORSO,
     },
 )

--- a/gym_kmanip/env_base.py
+++ b/gym_kmanip/env_base.py
@@ -187,15 +187,16 @@ class KManipEnv(gym.Env):
                 dtype=k.ACT_DTYPE,
             )
         self.action_space = spaces.Dict(_action_dict)
-        # self.action_len: int = len(self.action_space.spaces)
-        # pfb30
+        self.action_len: int = len(self.action_space.spaces)
+
+        # # pfb30 - actual change
+        self.action_len: int = 10 #len(self.q_id_r_mask)
         self.action_space = spaces.Box(
                 low=-1,
                 high=1,
-                shape=(len(self.q_id_r_mask),),
+                shape=(10,),
                 dtype=k.ACT_DTYPE,
         )
-        self.action_len: int = len(self.q_id_r_mask)
 
         # create either a sim or real environment
         self.sim: bool = sim

--- a/gym_kmanip/env_base.py
+++ b/gym_kmanip/env_base.py
@@ -187,9 +187,14 @@ class KManipEnv(gym.Env):
                 dtype=k.ACT_DTYPE,
             )
         self.action_space = spaces.Dict(_action_dict)
-
         # self.action_len: int = len(self.action_space.spaces)
         # pfb30
+        self.action_space = spaces.Box(
+                low=-1,
+                high=1,
+                shape=(len(self.q_id_r_mask),),
+                dtype=k.ACT_DTYPE,
+        )
         self.action_len: int = len(self.q_id_r_mask)
 
         # create either a sim or real environment

--- a/gym_kmanip/env_base.py
+++ b/gym_kmanip/env_base.py
@@ -187,7 +187,11 @@ class KManipEnv(gym.Env):
                 dtype=k.ACT_DTYPE,
             )
         self.action_space = spaces.Dict(_action_dict)
-        self.action_len: int = len(self.action_space.spaces)
+
+        # self.action_len: int = len(self.action_space.spaces)
+        # pfb30
+        self.action_len: int = len(self.q_id_r_mask)
+
         # create either a sim or real environment
         self.sim: bool = sim
         if self.sim:

--- a/gym_kmanip/env_sim.py
+++ b/gym_kmanip/env_sim.py
@@ -105,6 +105,8 @@ class KManipTask(base.Task):
         # print(f"ctrl raw: {ctrl}")
         ctrl = k.CTRL_ALPHA * ctrl + (1 - k.CTRL_ALPHA) * physics.data.ctrl.copy()
         # print(f"ctrl filtered: {ctrl}")
+        # pfb30
+        ctrl[:action.shape[0]] = action
         super().before_step(ctrl, physics)
 
     def get_observation(self, physics) -> dict:

--- a/gym_kmanip/env_sim.py
+++ b/gym_kmanip/env_sim.py
@@ -105,8 +105,10 @@ class KManipTask(base.Task):
         # print(f"ctrl raw: {ctrl}")
         ctrl = k.CTRL_ALPHA * ctrl + (1 - k.CTRL_ALPHA) * physics.data.ctrl.copy()
         # print(f"ctrl filtered: {ctrl}")
-        # pfb30
-        ctrl[:action.shape[0]] = action
+        # pfb30 - actual change
+        # physics.data.qpos[self.gym_env.q_id_r_mask] = action[self.gym_env.q_id_r_mask] 
+        ctrl[:] = action
+        print(ctrl)
         super().before_step(ctrl, physics)
 
     def get_observation(self, physics) -> dict:
@@ -129,6 +131,8 @@ class KManipTask(base.Task):
             # clip to [-1, 1]
             q_vel = np.clip(q_vel, -1, 1)
             obs["q_vel"] = q_vel[: self.gym_env.q_len]
+            # pfb30 
+            obs["q_vel"] = physics.data.ctrl
         if "cube_pos" in self.gym_env.obs_list:
             cube_pos: NDArray = physics.data.qpos[-7:-4].copy()
             # normalize cube pos to spawn range

--- a/gym_kmanip/examples/2_synthetic_data.py
+++ b/gym_kmanip/examples/2_synthetic_data.py
@@ -1,47 +1,69 @@
+"""
+Run:
+
+python gym_kmanip/examples/2_synthetic_data.py
+python gym_kmanip/examples/5_upload_dataset_to_hf.py
+"""
 import os
 import pprint
 
 import h5py
 import gymnasium as gym
 import numpy as np
-
+import imageio
 import gym_kmanip as k
 
 # choose your environment
-# ENV_NAME: str = "KManipSoloArm"
-# ENV_NAME: str = "KManipSoloArmQPos"
-ENV_NAME: str = "KManipSoloArmVision"
-# ENV_NAME: str = "KManipDualArm"
-# ENV_NAME: str = "KManipDualArmQPos"
-# ENV_NAME: str = "KManipDualArmVision"
-# ENV_NAME: str = "KManipTorso"
-# ENV_NAME: str = "KManipTorsoVision"
+# ENV_NAME: str = "gym_kmanip/KManipSoloArm"
+# ENV_NAME: str = "gym_kmanip/KManipSoloArmQPos"
+ENV_NAME: str = "gym_kmanip/KManipSoloArmVision"
+# ENV_NAME: str = "gym_kmanip/KManipDualArm"
+# ENV_NAME: str = "gym_kmanip/KManipDualArmQPos"
+# ENV_NAME: str = "gym_kmanip/KManipDualArmVision"
+# ENV_NAME: str = "gym_kmanip/KManipTorso"
+# ENV_NAME: str = "gym_kmanip/KManipTorsoVision"
+
+ENV = ENV_NAME.split("/")[1]
+DISTANCE_TERIMNATE = 0.015
+NUM_EPISODES: int = 100
+
 env = gym.make(
     ENV_NAME,
     log_h5py=True,
     log_rerun=True,
     log_prefix="sim_synth",
 )
-# env.reset()
 
-NUM_EPISODES: int = 10
-for _ in range(NUM_EPISODES):
+for episode in range(NUM_EPISODES):
+    frames = []
     env.reset()
+    # heuristic action moving towards cube
+    cube_pos = env.unwrapped.env.physics.data.qpos[-7:-4].copy()
     for _ in range(k.MAX_EPISODE_STEPS):
+        # this is fake action
         action  = env.action_space.sample()
-        # heuristic action moving towards cube
-        cube_pos = env.unwrapped.env.physics.data.qpos[-7:-4].copy()
+
+        image = env.render()
+        frames.append(image)
+
         eer_pos = env.unwrapped.env.physics.data.site("eer_site_pos").xpos.copy()
         raw_action = cube_pos - eer_pos
         raw_action /= np.linalg.norm(raw_action)
+        distance = np.linalg.norm(cube_pos - eer_pos)
+   
         print(f"raw_action: {raw_action}")
         action["eer_pos"] = raw_action
+        # breakpoint()
         _, _, terminated, truncated, _ = env.step(action)
+
+        if distance < DISTANCE_TERIMNATE:
+            terminated = True
         if terminated or truncated:
             break
 
-env.close()
+    imageio.mimsave(f"viz_{ENV}_{episode}.mp4", np.stack(frames), fps=k.FPS)
 
+env.close()
 log_path = os.path.join(env.unwrapped.log_dir, "episode_1.hdf5")
 print(f"Opening hdf5 file at \n\t{log_path}")
 f = h5py.File(log_path, "r")
@@ -50,5 +72,8 @@ print(f.keys())
 print("\nmetadata:\n")
 pprint.pprint(dict(f['metadata'].attrs.items()))
 print("\ndata:\n")
-print(f['observations/qpos'][0])
-print(f['observations/qvel'][0])
+print(f['action'])
+print(f['observations/qpos'])
+print(f['observations/qvel'])
+print(f['observations/images/head'])
+print(f['observations/images/grip_r'])

--- a/gym_kmanip/log_h5py.py
+++ b/gym_kmanip/log_h5py.py
@@ -52,8 +52,10 @@ def step(
     observation: Dict[str, NDArray],
     info: Dict[str, Any],
 ) -> None:
+
     id: int = info["step"] - 1
-    f["action"][id] = action["grip_r"]
+    # pfb30 - what do we save as a action!
+    f["action"][id] = observation["q_pos"][:f["action"].shape[1]]
     f["observations/qpos"][id] = observation["q_pos"]
     f["observations/qvel"][id] = observation["q_vel"]
     for cam in info["cameras"]:

--- a/gym_kmanip/log_h5py.py
+++ b/gym_kmanip/log_h5py.py
@@ -52,10 +52,9 @@ def step(
     observation: Dict[str, NDArray],
     info: Dict[str, Any],
 ) -> None:
-
     id: int = info["step"] - 1
-    # pfb30 - what do we save as a action!
-    f["action"][id] = observation["q_pos"][:f["action"].shape[1]]
+    # pfb30 - what do we save as a action
+    f["action"][id] = observation["q_vel"]
     f["observations/qpos"][id] = observation["q_pos"]
     f["observations/qvel"][id] = observation["q_vel"]
     for cam in info["cameras"]:


### PR DESCRIPTION
There are bunch of hacks that I made to get this to work. Unfortunately they are not straightforward to clean up:
1. https://github.com/budzianowski/lerobot - I have added stompy env to the lerobot:
lerobot/configs/policy/act_stompy.yaml and adapted eval protocol
2. I have added changes to `gym_kmanip/env_sim.py` and `gym_kmanip/env_base.py` which change the action policy to 10 position of the right arm.

The training runs with `budzianowski/sim_synth` dataset from https://huggingface.co/datasets/budzianowski/sim_synth

> python lerobot/scripts/train.py  \  
> policy=act_stompy_real  \  
> env=kmanip   \  
> env.task=KManipSoloArmVision  \  
> dataset_repo_id=budzianowski/sim_synth

TODO:
1. The main action point is to recreate the env so that the action space is 
> self.action_space = spaces.Box(low=-1, high=1, shape=(10,),dtype=k.ACT_DTYPE)
which is what lerobot expects.
2. Create the data with `gym_kmanip/examples/2_synthetic_data.py` with proper logic in `gym_kmanip/log_h5py.py`
3. Push the data with: `gym_kmanip/examples/5_upload_dataset_to_hf.py`
4. Train and eval in one loop.